### PR TITLE
This PR fixes 1 issues thanks to snyk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
It updates org.apache.logging.log4j:log4j-core from version 2.15.0 to version 2.16.0.
Review relevant docs for possible breaking changes.


To find more details, see the Snyk project [gh-xt&#x2F;snyk-boot-web:pom.xml](https:&#x2F;&#x2F;app.snyk.io&#x2F;org&#x2F;gh-xt&#x2F;project&#x2F;01ef15a4-9c99-4f96-a85a-7cacc5d8bfdc?utm_source&#x3D;github&amp;utm_medium&#x3D;referral&amp;page&#x3D;fix-pr)


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["issue_count","package_name","package_from","package_to","snyk_project_name","snyk_project_url"],"fieldsUsed":["commitMessage","description","title"]},"dependencies":[{"name":"org.apache.logging.log4j:log4j-core","from":"2.15.0","to":"2.16.0"}],"env":"prod","issuesToFix":["SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2320014"],"prId":"c6f269f7-ee76-45b1-a260-01ebf0aa3d01","prPublicId":"c6f269f7-ee76-45b1-a260-01ebf0aa3d01","packageManager":"maven","priorityScoreList":[879],"projectPublicId":"01ef15a4-9c99-4f96-a85a-7cacc5d8bfdc","projectUrl":"https://app.snyk.io/org/gh-xt/project/01ef15a4-9c99-4f96-a85a-7cacc5d8bfdc?utm_source=github&utm_medium=referral&page=fix-pr","prType":"fix","templateFieldSources":{"branchName":"default","commitMessage":"repository","description":"repository","title":"repository"},"templateVariants":["custom","updated-fix-title","priorityScore"],"type":"user-initiated","upgrade":["SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2320014"],"vulns":["SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2320014"],"patch":[],"isBreakingChange":false,"remediationStrategy":"vuln"}'