### PR TITLE
This PR fixes 5 issues thanks to snyk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 openjdk:11.0.13-slim-buster
+FROM --platform=linux/amd64 openjdk:11.0.16-jdk-slim-bullseye
 #FROM --platform=linux/amd64 openjdk:21-slim-bullseye
 
 RUN addgroup --system javauser && adduser --system --home /home/javauser --ingroup javauser javauser


### PR DESCRIPTION
It updates openjdk from version 11.0.13-slim-buster to version 11.0.16-jdk-slim-bullseye.
Review relevant docs for possible breaking changes.


To find more details, see the Snyk project [gh-xt&#x2F;snyk-boot-web:Dockerfile](https:&#x2F;&#x2F;app.snyk.io&#x2F;org&#x2F;gh-xt&#x2F;project&#x2F;2ce3b8b6-b7ab-474d-ab62-10414cd1a120?utm_source&#x3D;github&amp;utm_medium&#x3D;referral&amp;page&#x3D;fix-pr)


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["issue_count","package_name","package_from","package_to","snyk_project_name","snyk_project_url"],"fieldsUsed":["commitMessage","description","title"]},"dependencies":[{"name":"openjdk","from":"11.0.13-slim-buster","to":"11.0.16-jdk-slim-bullseye"}],"env":"prod","issuesToFix":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-OPENSSL-2933515","SNYK-DEBIAN10-GLIBC-1296899"],"prId":"5c75a755-7ca7-40b9-a097-f9e219304fb2","prPublicId":"5c75a755-7ca7-40b9-a097-f9e219304fb2","packageManager":"dockerfile","priorityScoreList":[786,714,714,714],"projectPublicId":"2ce3b8b6-b7ab-474d-ab62-10414cd1a120","projectUrl":"https://app.snyk.io/org/gh-xt/project/2ce3b8b6-b7ab-474d-ab62-10414cd1a120?utm_source=github&utm_medium=referral&page=fix-pr","prType":"fix","templateFieldSources":{"branchName":"default","commitMessage":"repository","description":"repository","title":"repository"},"templateVariants":["custom","updated-fix-title","priorityScore"],"type":"user-initiated","upgrade":["SNYK-DEBIAN10-GLIBC-1296899","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-OPENSSL-2933515","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153"],"vulns":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-OPENSSL-2933515","SNYK-DEBIAN10-GLIBC-1296899"],"patch":[],"isBreakingChange":false,"remediationStrategy":"vuln"}'